### PR TITLE
Use copyright symbol in config directly instead of HTML encoded value

### DIFF
--- a/src/NuGet.Status/Web.config
+++ b/src/NuGet.Status/Web.config
@@ -32,7 +32,7 @@
     <add key="Ida:ClientId" value="" />
     <add key="Ida:Tenant" value="" />
     
-    <add key="ExternalBrandingMessage" value="&#169; Microsoft 2019" />
+    <add key="ExternalBrandingMessage" value="© Microsoft 2019" />
     <add key="ExternalPrivacyPolicyUrl" value="https://go.microsoft.com/fwlink/?LinkId=521839" />
     <add key="TrademarksUrl" value="https://www.microsoft.com/trademarks" />
 


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6983

Both seem to work locally, but the HTML encoding does not appear to display properly in Azure.