### PR TITLE
Fix status page admin login infinite loop

### DIFF
--- a/src/NuGet.Status/App_Start/Startup.cs
+++ b/src/NuGet.Status/App_Start/Startup.cs
@@ -44,8 +44,7 @@ namespace NuGet.Status
                     CookieHttpOnly = true,
                     CookieSecure = CookieSecureOption.Always,
                     ExpireTimeSpan = TimeSpan.FromMinutes(10),
-                    SlidingExpiration = true,
-                    CookieManager = new SystemWebChunkingCookieManager()
+                    SlidingExpiration = true
                 };
 
                 app.UseCookieAuthentication(options);
@@ -57,7 +56,7 @@ namespace NuGet.Status
                         Authority = _authority,
                         RedirectUri = _redirectUri,
                         PostLogoutRedirectUri = _rootUri,
-                        TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
+                        TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
                         {
                             ValidateIssuer = false,
                             RoleClaimType = "roles"

--- a/src/NuGet.Status/App_Start/Startup.cs
+++ b/src/NuGet.Status/App_Start/Startup.cs
@@ -44,7 +44,8 @@ namespace NuGet.Status
                     CookieHttpOnly = true,
                     CookieSecure = CookieSecureOption.Always,
                     ExpireTimeSpan = TimeSpan.FromMinutes(10),
-                    SlidingExpiration = true
+                    SlidingExpiration = true,
+                    CookieManager = new SystemWebChunkingCookieManager()
                 };
 
                 app.UseCookieAuthentication(options);

--- a/src/NuGet.Status/App_Start/Startup.cs
+++ b/src/NuGet.Status/App_Start/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Owin;
+using Microsoft.Owin.Host.SystemWeb;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
@@ -43,7 +44,8 @@ namespace NuGet.Status
                     CookieHttpOnly = true,
                     CookieSecure = CookieSecureOption.Always,
                     ExpireTimeSpan = TimeSpan.FromMinutes(10),
-                    SlidingExpiration = true
+                    SlidingExpiration = true,
+                    CookieManager = new SystemWebChunkingCookieManager()
                 };
 
                 app.UseCookieAuthentication(options);
@@ -55,7 +57,7 @@ namespace NuGet.Status
                         Authority = _authority,
                         RedirectUri = _redirectUri,
                         PostLogoutRedirectUri = _rootUri,
-                        TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
+                        TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
                         {
                             ValidateIssuer = false,
                             RoleClaimType = "roles"

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -171,7 +171,7 @@
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
       <Version>3.0.1</Version>

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -171,16 +171,16 @@
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
-      <Version>4.1.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
-      <Version>4.1.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect">
-      <Version>4.1.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.StaticFiles">
-      <Version>4.1.0</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager">
       <Version>3.1.0</Version>

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -174,7 +174,7 @@
       <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
-      <Version>3.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect">
       <Version>4.1.0</Version>

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -171,16 +171,16 @@
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
-      <Version>3.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
       <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect">
-      <Version>3.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.StaticFiles">
-      <Version>3.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager">
       <Version>3.1.0</Version>

--- a/src/NuGet.Status/Web.config
+++ b/src/NuGet.Status/Web.config
@@ -54,6 +54,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>

--- a/src/NuGet.Status/Web.config
+++ b/src/NuGet.Status/Web.config
@@ -54,14 +54,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>

--- a/src/NuGet.Status/Web.config
+++ b/src/NuGet.Status/Web.config
@@ -54,6 +54,14 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
       </dependentAssembly>


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/2012 

This is kind of a difficult fix, I wasn't able to get a full fledged repro locally. From what I understand on reading up for issues with similar symptoms, there seems to be an issue with Katana owin middleware in particular on how the cookies are written with `set-cookie header`, particularly with `System.Web.Cookies` and `Owin.Cookies` collision. See the references on the issue details which seem to be the same for our scenario. Applying the same recommended fix for us with this PR.

Verified this on DEV(that it doesn't break anything, kind of hard to get the repro since it happens randomly). I will deploy this through to PROD and follow up for a week to see if we get into infinite loop again.

References:
1. https://blogs.aaddevsup.xyz/2019/11/infinite-sign-in-loop-between-mvc-application-and-azure-ad/
1. https://varnerin.info/infinite-redirects-with-aspnet-owin-and-openid-connect/