### PR TITLE
Restrict package sources

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Restrict package sources to those explicitly listed in the `nuget.config` file. This prevents build issues where packages may come from unexpected package sources due to other `nuget.config` files (see [this](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#config-file-locations-and-uses)).

Verification build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=4332483&view=results

Part of https://github.com/NuGet/Engineering/issues/3525