### PR TITLE
More straightforward code for configuration refresh that also honors cancellation token

### DIFF
--- a/src/NuGet.Status/Global.asax.cs
+++ b/src/NuGet.Status/Global.asax.cs
@@ -82,9 +82,11 @@ namespace NuGet.Status
 
         private async Task RefreshConfigurationForever(CancellationToken token)
         {
-            await Task.Delay(ConfigurationRefreshPeriod);
-            StatusConfiguration = await _configurationFactory.Get<StatusConfiguration>();
-            await RefreshConfigurationForever(token);
+            while (!token.IsCancellationRequested)
+            {
+                await Task.Delay(ConfigurationRefreshPeriod, token);
+                StatusConfiguration = await _configurationFactory.Get<StatusConfiguration>();
+            }
         }
     }
 }


### PR DESCRIPTION
Replaced "recursion" with a loop that checks token cancellation status, so we don't waste memory in async state machine and get nicer exception stack traces if any.
Passing cancellation token into `Task.Delay` so it would actually stop if requested.