### PR TITLE
[CDN] Remove CDN status

### DIFF
--- a/src/NuGet.Status/Extensions/UrlExtensions.cs
+++ b/src/NuGet.Status/Extensions/UrlExtensions.cs
@@ -123,5 +123,10 @@ namespace NuGet.Status.Helpers
         {
             return url.RequestContext.HttpContext.Request.RawUrl;
         }
+
+        public static string GetCanonicalLinkUrl(this UrlHelper url)
+        {
+            return "";
+        }
     }
 }

--- a/src/NuGet.Status/Helpers/AdminHelper.cs
+++ b/src/NuGet.Status/Helpers/AdminHelper.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Status.Helpers
+{
+    public static class AdminHelper
+    {
+        public static bool IsAdminPanelEnabled => false;
+    }
+}

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\AdminAuthorizeAttribute.cs" />
+    <Compile Include="Helpers\AdminHelper.cs" />
     <Compile Include="Helpers\CachedServiceStatus.cs" />
     <Compile Include="Helpers\CoreConstants.cs" />
     <Compile Include="Helpers\ServiceStatusHelper.cs" />

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -135,7 +135,6 @@
     <Content Include="Views\Home\_StatusUpdates.cshtml" />
     <Content Include="Service References\Application Insights\ConnectedService.json" />
     <Content Include="Views\Home\_LatestStatusUpdate.cshtml" />
-    <Content Include="Views\Home\_CdnStatus.cshtml" />
     <Content Include="Views\Admin\Index.cshtml" />
     <Content Include="Views\Admin\_Create.cshtml" />
     <Content Include="Views\Admin\_Edit.cshtml" />

--- a/src/NuGet.Status/Views/Home/Index.cshtml
+++ b/src/NuGet.Status/Views/Home/Index.cshtml
@@ -47,11 +47,6 @@
             @Html.Partial("_ServiceStatus", Model)
         </div>
     </div>
-    <div class="row">
-        <div class="col-xs-12">
-            @Html.Partial("_CdnStatus", Model)
-        </div>
-    </div>
     @if (Model != null && Model.Events != null && Model.Events.Any())
     {
         <div class="row">

--- a/src/NuGet.Status/Views/Home/_CdnStatus.cshtml
+++ b/src/NuGet.Status/Views/Home/_CdnStatus.cshtml
@@ -1,7 +1,0 @@
-﻿@using NuGet.Services.Status
-@model ServiceStatus
-
-<h2>CDN Status</h2>
-
-<p>If you experience connectivity issues but all other indicators on this status page look normal, there may be an issue with our Content Delivery Network (CDN).</p>
-<p><a href="https://status.verizondigitalmedia.com/#network-status" target="_blank">Verify CDN network status.</a></p>

--- a/src/NuGet.Status/Views/StatusViewBase.cs
+++ b/src/NuGet.Status/Views/StatusViewBase.cs
@@ -33,6 +33,8 @@ namespace NuGet.Status.Views
         public bool DeprecateNuGetPasswordLogins => false;
 
         public string ExternalStatusUrl => "/";
+
+        public string SiteRoot => "";
     }
 
     public class Config


### PR DESCRIPTION
As the multi-CDN infrastructure is alive, we will remove CDN Status from the status page:
(Some fixes are needed to resolve the runtime issue.)
![image](https://user-images.githubusercontent.com/41028779/165804416-b381f6a1-99fa-4eaf-a637-246aaf0f383e.png)

Before:
![image](https://user-images.githubusercontent.com/41028779/165804885-731b6f2c-c2a1-468e-a17f-80ca03386c7b.png)

