### PR TITLE
Update moment.js to match the Gallery version

### DIFF
--- a/src/NuGet.Status/App_Start/BundleConfig.cs
+++ b/src/NuGet.Status/App_Start/BundleConfig.cs
@@ -17,9 +17,8 @@ namespace NuGet.Status
                     "~/Scripts/gallery/jquery-3.4.1.js",
                     "~/Scripts/gallery/jquery.validate-1.16.0.js",
                     "~/Scripts/gallery/jquery.validate.unobtrusive-3.2.6.js",
-                    "~/Scripts/gallery/knockout-3.4.2.js",
                     "~/Scripts/gallery/bootstrap.js",
-                    "~/Scripts/gallery/moment-2.18.1.js",
+                    "~/Scripts/gallery/moment-2.29.4.js",
                     "~/Scripts/gallery/common.js",
                     "~/Scripts/gallery/page-status.js"));
         }

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -192,6 +192,9 @@
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager">
       <Version>3.1.0</Version>
     </PackageReference>
+    <PackageReference Include="Moment.js">
+      <Version>2.29.4</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
     </PackageReference>


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/9202

- The moment.js link was broken for since the version changed
- Updated to latest gallery submodule to avoid CG issue
- Add explicit PackageReference for moment.js to opt into CG for moment.js (just like Gallery)