### PR TITLE
Move from ADAL to MSAL

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding(DefaultParameterSetName='RegularBuild')]
+[CmdletBinding(DefaultParameterSetName = 'RegularBuild')]
 param (
     [ValidateSet("debug", "release")]
     [string]$Configuration = 'debug',
@@ -11,7 +11,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = 'd298565f387e93995a179ef8ae6838f1be37904f'
+    [string]$BuildBranch = '344f549684897666a619724271c36002405908bd' # DevSkim: ignore DS173237. It's a commit hash.
 )
 
 Set-StrictMode -Version 1.0
@@ -28,9 +28,6 @@ trap {
 if (-not (Test-Path "$PSScriptRoot/build")) {
     New-Item -Path "$PSScriptRoot/build" -ItemType "directory"
 }
-
-# Enable TLS 1.2 since GitHub requires it.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
 Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/NuGet/ServerCommon/$BuildBranch/build/init.ps1" -OutFile "$PSScriptRoot/build/init.ps1"
 . "$PSScriptRoot/build/init.ps1" -BuildBranch "$BuildBranch"
@@ -60,8 +57,8 @@ Invoke-BuildStep 'Reset all submodules' { Reset-Submodules } `
     -ev +BuildErrors
 
 Invoke-BuildStep "Update NuGetGallery submodule" {
-        Invoke-Git 'submodule', 'update', '--init', '--', 'src/NuGet.Status/NuGetGallery'
-    } `
+    Invoke-Git 'submodule', 'update', '--init', '--', 'src/NuGet.Status/NuGetGallery'
+} `
     -skip:($SkipSubModules) `
     -ev +BuildErrors
     
@@ -82,25 +79,25 @@ Invoke-BuildStep 'Clearing artifacts' { Clear-Artifacts } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Restoring solution packages' { `
-    Install-SolutionPackages -path (Join-Path $PSScriptRoot ".nuget\packages.config") -output (Join-Path $PSScriptRoot "packages") -excludeversion } `
+        Install-SolutionPackages -path (Join-Path $PSScriptRoot ".nuget\packages.config") -output (Join-Path $PSScriptRoot "packages") -excludeversion } `
     -skip:$SkipRestore `
     -ev +BuildErrors
     
 Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' {
     $Paths = `
-        (Join-Path $PSScriptRoot "src\NuGet.Status\Properties\AssemblyInfo.g.cs")
+    (Join-Path $PSScriptRoot "src\NuGet.Status\Properties\AssemblyInfo.g.cs")
 
     Foreach ($Path in $Paths) {
         Set-VersionInfo -Path $Path -Version $SimpleVersion -Branch $Branch -Commit $CommitSHA
     }
 } `
--ev +BuildErrors
+    -ev +BuildErrors
 
 Invoke-BuildStep 'Building solution' { 
     $SolutionPath = Join-Path $PSScriptRoot "src\NuGet.Status.sln"
     Build-Solution $Configuration $BuildNumber -MSBuildVersion "15" $SolutionPath -SkipRestore:$SkipRestore `
 } `
--ev +BuildErrors
+    -ev +BuildErrors
 
 Trace-Log ('-' * 60)
 
@@ -112,7 +109,7 @@ Trace-Log "Time elapsed $(Format-ElapsedTime ($endTime - $startTime))"
 Trace-Log ('=' * 60)
 
 if ($BuildErrors) {
-    $ErrorLines = $BuildErrors | %{ ">>> $($_.Exception.Message)" }
+    $ErrorLines = $BuildErrors | % { ">>> $($_.Exception.Message)" }
     Error-Log "Builds completed with $($BuildErrors.Count) error(s):`r`n$($ErrorLines -join "`r`n")" -Fatal
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = '344f549684897666a619724271c36002405908bd' # DevSkim: ignore DS173237. It's a commit hash.
+    [string]$BuildBranch = '5295c6e0d2ae7357fccf01e48c56b768b192f022' # DevSkim: ignore DS173237. It's a commit hash.
 )
 
 Set-StrictMode -Version 1.0

--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,7 @@
     <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -199,10 +199,10 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.111.0</Version>
+      <Version>2.113.0-jver-msal-8428984</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.111.0</Version>
+      <Version>2.113.0-jver-msal-8428984</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>6.6.1</Version>

--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -199,10 +199,10 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.113.0-jver-msal-8428984</Version>
+      <Version>2.113.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.113.0-jver-msal-8428984</Version>
+      <Version>2.113.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>6.6.1</Version>

--- a/src/NuGet.Status/Views/Web.config
+++ b/src/NuGet.Status/Views/Web.config
@@ -9,7 +9,7 @@
   </configSections>
 
   <system.web.webPages.razor>
-    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
     <pages pageBaseType="NuGet.Status.Views.StatusViewBase">
       <namespaces>
         <add namespace="System.Web.Mvc" />

--- a/src/NuGet.Status/Web.config
+++ b/src/NuGet.Status/Web.config
@@ -55,6 +55,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
@@ -83,32 +87,16 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.25.0.0" newVersion="1.25.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.6.0" newVersion="5.2.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.25.0.0" newVersion="1.25.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4992

Summary of the changes:
- Drop `Microsoft.IdentityModel.Clients.ActiveDirectory` (ADAL), pick up `Microsoft.Identity.Client` (MSAL)
- Move to latest ServerCommon to pull in MSAL move
- Move to matching NuGetGallery commit
- Update build tools to latest to drop ADAL reference in a tool
- Resolve minor DevSkim warnings
- Fix bad MVC assembly reference causing a hard to identify binding redirect need