### PR TITLE
Update Gallery as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/NuGet.Status/NuGetGallery"]
+	path = src/NuGet.Status/NuGetGallery
+	url = https://github.com/NuGet/NuGetGallery.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/NuGet.Status/NuGetGallery"]
-	path = src/NuGet.Status/NuGetGallery
-	url = https://github.com/NuGet/NuGetGallery.git


### PR DESCRIPTION
CG alert from Gallery, which is submodule of NuGet.Services.Status. and we haven't updated since 2 two years ago. 

Pull latest submodule for NuGetGallery to revole the CG alert, which we already addressed in NuGetGallery

Address: https://github.com/NuGet/Engineering/issues/5704