### PR TITLE
Update Packages

### DIFF
--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -122,6 +122,7 @@
     <Content Include="NuGetGallery\src\Bootstrap\dist\css\bootstrap.css" />
     <Content Include="NuGetGallery\src\Bootstrap\dist\css\bootstrap-theme.css" />
     <Content Include="NuGetGallery\src\NuGetGallery\Views\**" />
+    <Content Remove="NuGetGallery\src\nugetcdnredirect\web.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="ApplicationInsights.config">
@@ -157,13 +158,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.2.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.JavaScript">
       <Version>0.11.0-build09387</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Web">
-      <Version>2.2.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Web.TelemetryChannel">
       <Version>1.0.0</Version>
@@ -178,6 +179,9 @@
       <Version>6.0.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens">
+      <Version>8.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
       <Version>4.2.2</Version>
@@ -205,6 +209,9 @@
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>6.6.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt">
+      <Version>8.11.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
New build here: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=11659431&view=results
release build failed with following messages: 
```
  "D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status.sln" (default target) (1) ->
       "D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj" (default target) (2) ->
       (CreateCompilerGeneratedFilesOutputPath target) -> 
         c:\program files\microsoft visual studio\2022\enterprise\msbuild\current\bin\Roslyn\Microsoft.Managed.Core.targets(339,5): warning : EmitCompilerGeneratedFiles was true, but no CompilerGeneratedFilesOutputPath was provided. CompilerGeneratedFilesOutputPath must be set in order to emit generated files. [D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj]


       "D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status.sln" (default target) (1) ->
       "D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj" (default target) (2) ->
       (MvcBuildViews target) -> 
         ASPNETCOMPILER : warning : The following assembly has dependencies on a version of the .NET Framework that is higher than the target and might not load correctly during runtime causing a failure: NuGet.Status, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35. The dependencies are: System.Net.Http, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a. You should either ensure that the dependent assembly is correct for the target framework, or ensure that the target framework you are addressing is that of the dependent assembly. [D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj]
         ASPNETCOMPILER : warning CS1685: The predefined type 'System.ObsoleteAttribute' is defined in multiple assemblies in the global alias; using definition from 'c:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\mscorlib.dll' [D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj]
         ASPNETCOMPILER : warning CS1685: The predefined type 'System.ObsoleteAttribute' is defined in multiple assemblies in the global alias; using definition from 'c:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\mscorlib.dll' [D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj]


       "D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status.sln" (default target) (1) ->
       "D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj" (default target) (2) ->
       (MvcBuildViews target) -> 
         D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\nugetgallery\src\nugetcdnredirect\web.config(61): error ASPCONFIG: It is an error to use a section registered as allowDefinition='MachineToApplication' beyond application level.  This error can be caused by a virtual directory not being configured as an application in IIS. [D:\a\_work\1\s\nd\src\Status\submodules\NuGet.Status\src\NuGet.Status\NuGet.Status.csproj]

    4 Warning(s)
    1 Error(s)

```https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=11630870&view=logs&j=8515a029-22a6-5510-9e17-f5665af94c87&t=5642f12b-ae93-5ea6-ad52-fb38f52114ef



