### PR TITLE
Bump JWT package versions

### DIFF
--- a/src/NuGet.Status/NuGet.Status.csproj
+++ b/src/NuGet.Status/NuGet.Status.csproj
@@ -195,6 +195,8 @@
     <PackageReference Include="Microsoft.Owin.StaticFiles">
       <Version>4.2.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.7.0"/>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0"/>
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager">
       <Version>3.1.0</Version>
     </PackageReference>


### PR DESCRIPTION
The JWT packages were resolved indirectly via Owin packages. To satisfy component governance we need to explicitly reference the right package verions.
Addresses
https://github.com/NuGet/Engineering/issues/5976
https://github.com/NuGet/Engineering/issues/5977 