### PR TITLE
Enable package version override in Directory.Packages.props

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <EnablePackageVersionOverride>true</EnablePackageVersionOverride>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Related: https://nuget.visualstudio.com/NuGetBuild/_git/NuGetBuild/pullrequest/2784

This is necessary to fix the NuGet Status build pipeline which pulls in NuGetBuild which doesn't use CPM in their targets. The mismatch is causing errors.